### PR TITLE
Dave Saunders submission

### DIFF
--- a/OpenMoney.InterviewExercise.Tests/HomeInsuranceQuoteClientFixture.cs
+++ b/OpenMoney.InterviewExercise.Tests/HomeInsuranceQuoteClientFixture.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Moq;
 using OpenMoney.InterviewExercise.Models;
 using OpenMoney.InterviewExercise.QuoteClients;
@@ -95,6 +96,26 @@ namespace OpenMoney.InterviewExercise.Tests
             });
 
             Assert.Equal(12m, (decimal)quote.MonthlyPayment);
+        }
+
+
+
+        [Fact]
+        public void GetQuote_ShouldReturnNull_When_No_Quotes_Returned()
+        {
+            const float houseValue = 100_000;
+
+            _apiMock
+                .Setup(api => api.GetQuotes(It.Is<ThirdPartyHomeInsuranceRequest>(r =>
+                    r.ContentsValue == 50_000 && r.HouseValue == (decimal)houseValue)))
+                .ReturnsAsync(Enumerable.Empty<ThirdPartyHomeInsuranceResponse>());
+
+            var quote = _homeInsuranceClient.GetQuote(new GetQuotesRequest
+            {
+                HouseValue = houseValue
+            });
+
+            Assert.Null(quote);
         }
     }
 }

--- a/OpenMoney.InterviewExercise.Tests/HomeInsuranceQuoteClientFixture.cs
+++ b/OpenMoney.InterviewExercise.Tests/HomeInsuranceQuoteClientFixture.cs
@@ -9,6 +9,12 @@ namespace OpenMoney.InterviewExercise.Tests
     public class HomeInsuranceQuoteClientFixture
     {
         private readonly Mock<IThirdPartyHomeInsuranceApi> _apiMock = new();
+        private readonly HomeInsuranceQuoteClient _homeInsuranceClient;
+
+        public HomeInsuranceQuoteClientFixture()
+        {
+            _homeInsuranceClient = new HomeInsuranceQuoteClient(_apiMock.Object);
+        }
 
         [Fact]
         public void GetQuote_ShouldReturnNull_IfHouseValue_Over10Mill()
@@ -23,9 +29,32 @@ namespace OpenMoney.InterviewExercise.Tests
             
             Assert.Null(quote);
         }
+        
+        [Fact]
+        public void GetQuote_ShouldReturnQuote_IfHouseValue_Is_Exactly_10Million()
+        {
+            // The test above proves that 10,000,001 returns null, but not that the threshold 
+            // is actually set at 10 million (it could be set to 9 million and that test would still pass).
+            // This test asserts that the threshold is set correctly
+            
+            const float houseValue = 10_000_000;
+
+            _apiMock
+                .Setup(api => api.GetQuotes(It.IsAny<ThirdPartyHomeInsuranceRequest>()))
+                .ReturnsAsync(new[]
+                {
+                    new ThirdPartyHomeInsuranceResponse { MonthlyPayment = 30 }
+                });
+
+            var quote = _homeInsuranceClient.GetQuote(new GetQuotesRequest {
+                HouseValue = houseValue
+            });
+
+            Assert.NotNull(quote);
+        }
 
         [Fact]
-        public void GetQuote_ShouldReturn_AQuote()
+        public void GetQuote_Should_Return_Quote_When_Only_One_Available()
         {
             const float houseValue = 100_000;
 
@@ -37,13 +66,35 @@ namespace OpenMoney.InterviewExercise.Tests
                     new ThirdPartyHomeInsuranceResponse { MonthlyPayment = 30 }
                 });
             
-            var mortgageClient = new HomeInsuranceQuoteClient(_apiMock.Object);
-            var quote = mortgageClient.GetQuote(new GetQuotesRequest
+            var quote = _homeInsuranceClient.GetQuote(new GetQuotesRequest
             {
                 HouseValue = houseValue
             });
             
             Assert.Equal(30m, (decimal)quote.MonthlyPayment);
+        }
+
+        [Fact]
+        public void GetQuote_ShouldReturnCheapestMonthlyPayment_When_Multiple_Quotes_Returned()
+        {
+            const float houseValue = 100_000;
+
+            _apiMock
+                .Setup(api => api.GetQuotes(It.Is<ThirdPartyHomeInsuranceRequest>(r =>
+                    r.ContentsValue == 50_000 && r.HouseValue == (decimal)houseValue)))
+                .ReturnsAsync(new[]
+                {
+                    new ThirdPartyHomeInsuranceResponse { MonthlyPayment = 30 },
+                    new ThirdPartyHomeInsuranceResponse { MonthlyPayment = 1000 },
+                    new ThirdPartyHomeInsuranceResponse { MonthlyPayment = 12 },
+                });
+
+            var quote = _homeInsuranceClient.GetQuote(new GetQuotesRequest
+            {
+                HouseValue = houseValue
+            });
+
+            Assert.Equal(12m, (decimal)quote.MonthlyPayment);
         }
     }
 }

--- a/OpenMoney.InterviewExercise.Tests/HomeInsuranceQuoteClientFixture.cs
+++ b/OpenMoney.InterviewExercise.Tests/HomeInsuranceQuoteClientFixture.cs
@@ -20,7 +20,7 @@ namespace OpenMoney.InterviewExercise.Tests
         [Fact]
         public void GetQuote_ShouldReturnNull_IfHouseValue_Over10Mill()
         {
-            const float houseValue = 10_000_001;
+            const decimal houseValue = 10_000_001;
             
             var mortgageClient = new HomeInsuranceQuoteClient(_apiMock.Object);
             var quote = mortgageClient.GetQuote(new GetQuotesRequest
@@ -38,7 +38,7 @@ namespace OpenMoney.InterviewExercise.Tests
             // is actually set at 10 million (it could be set to 9 million and that test would still pass).
             // This test asserts that the threshold is set correctly
             
-            const float houseValue = 10_000_000;
+            const decimal houseValue = 10_000_000;
 
             _apiMock
                 .Setup(api => api.GetQuotes(It.IsAny<ThirdPartyHomeInsuranceRequest>()))
@@ -57,11 +57,11 @@ namespace OpenMoney.InterviewExercise.Tests
         [Fact]
         public void GetQuote_Should_Return_Quote_When_Only_One_Available()
         {
-            const float houseValue = 100_000;
+            const decimal houseValue = 100_000;
 
             _apiMock
                 .Setup(api => api.GetQuotes(It.Is<ThirdPartyHomeInsuranceRequest>(r =>
-                    r.ContentsValue == 50_000 && r.HouseValue == (decimal) houseValue)))
+                    r.ContentsValue == 50_000 && r.HouseValue == houseValue)))
                 .ReturnsAsync(new[]
                 {
                     new ThirdPartyHomeInsuranceResponse { MonthlyPayment = 30 }
@@ -72,17 +72,17 @@ namespace OpenMoney.InterviewExercise.Tests
                 HouseValue = houseValue
             });
             
-            Assert.Equal(30m, (decimal)quote.MonthlyPayment);
+            Assert.Equal(30m, quote.MonthlyPayment);
         }
 
         [Fact]
         public void GetQuote_ShouldReturnCheapestMonthlyPayment_When_Multiple_Quotes_Returned()
         {
-            const float houseValue = 100_000;
+            const decimal houseValue = 100_000;
 
             _apiMock
                 .Setup(api => api.GetQuotes(It.Is<ThirdPartyHomeInsuranceRequest>(r =>
-                    r.ContentsValue == 50_000 && r.HouseValue == (decimal)houseValue)))
+                    r.ContentsValue == 50_000 && r.HouseValue == houseValue)))
                 .ReturnsAsync(new[]
                 {
                     new ThirdPartyHomeInsuranceResponse { MonthlyPayment = 30 },
@@ -95,19 +95,17 @@ namespace OpenMoney.InterviewExercise.Tests
                 HouseValue = houseValue
             });
 
-            Assert.Equal(12m, (decimal)quote.MonthlyPayment);
+            Assert.Equal(12m, quote.MonthlyPayment);
         }
-
-
-
+        
         [Fact]
         public void GetQuote_ShouldReturnNull_When_No_Quotes_Returned()
         {
-            const float houseValue = 100_000;
+            const decimal houseValue = 100_000;
 
             _apiMock
                 .Setup(api => api.GetQuotes(It.Is<ThirdPartyHomeInsuranceRequest>(r =>
-                    r.ContentsValue == 50_000 && r.HouseValue == (decimal)houseValue)))
+                    r.ContentsValue == 50_000 && r.HouseValue == houseValue)))
                 .ReturnsAsync(Enumerable.Empty<ThirdPartyHomeInsuranceResponse>());
 
             var quote = _homeInsuranceClient.GetQuote(new GetQuotesRequest

--- a/OpenMoney.InterviewExercise.Tests/HomeInsuranceQuoteClientFixture.cs
+++ b/OpenMoney.InterviewExercise.Tests/HomeInsuranceQuoteClientFixture.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading.Tasks;
 using Moq;
 using OpenMoney.InterviewExercise.Models;
 using OpenMoney.InterviewExercise.QuoteClients;
@@ -18,12 +19,11 @@ namespace OpenMoney.InterviewExercise.Tests
         }
 
         [Fact]
-        public void GetQuote_ShouldReturnNull_IfHouseValue_Over10Mill()
+        public async Task GetQuote_ShouldReturnNull_IfHouseValue_Over10Mill()
         {
             const decimal houseValue = 10_000_001;
             
-            var mortgageClient = new HomeInsuranceQuoteClient(_apiMock.Object);
-            var quote = mortgageClient.GetQuote(new GetQuotesRequest
+            var quote = await _homeInsuranceClient.GetQuote(new GetQuotesRequest
             {
                 HouseValue = houseValue
             });
@@ -32,7 +32,7 @@ namespace OpenMoney.InterviewExercise.Tests
         }
         
         [Fact]
-        public void GetQuote_ShouldReturnQuote_IfHouseValue_Is_Exactly_10Million()
+        public async Task GetQuote_ShouldReturnQuote_IfHouseValue_Is_Exactly_10Million()
         {
             // The test above proves that 10,000,001 returns null, but not that the threshold 
             // is actually set at 10 million (it could be set to 9 million and that test would still pass).
@@ -47,7 +47,7 @@ namespace OpenMoney.InterviewExercise.Tests
                     new ThirdPartyHomeInsuranceResponse { MonthlyPayment = 30 }
                 });
 
-            var quote = _homeInsuranceClient.GetQuote(new GetQuotesRequest {
+            var quote = await _homeInsuranceClient.GetQuote(new GetQuotesRequest {
                 HouseValue = houseValue
             });
 
@@ -55,7 +55,7 @@ namespace OpenMoney.InterviewExercise.Tests
         }
 
         [Fact]
-        public void GetQuote_Should_Return_Quote_When_Only_One_Available()
+        public async Task GetQuote_Should_Return_Quote_When_Only_One_Available()
         {
             const decimal houseValue = 100_000;
 
@@ -67,7 +67,7 @@ namespace OpenMoney.InterviewExercise.Tests
                     new ThirdPartyHomeInsuranceResponse { MonthlyPayment = 30 }
                 });
             
-            var quote = _homeInsuranceClient.GetQuote(new GetQuotesRequest
+            var quote = await _homeInsuranceClient.GetQuote(new GetQuotesRequest
             {
                 HouseValue = houseValue
             });
@@ -76,7 +76,7 @@ namespace OpenMoney.InterviewExercise.Tests
         }
 
         [Fact]
-        public void GetQuote_ShouldReturnCheapestMonthlyPayment_When_Multiple_Quotes_Returned()
+        public async Task GetQuote_ShouldReturnCheapestMonthlyPayment_When_Multiple_Quotes_Returned()
         {
             const decimal houseValue = 100_000;
 
@@ -90,7 +90,7 @@ namespace OpenMoney.InterviewExercise.Tests
                     new ThirdPartyHomeInsuranceResponse { MonthlyPayment = 12 },
                 });
 
-            var quote = _homeInsuranceClient.GetQuote(new GetQuotesRequest
+            var quote = await _homeInsuranceClient.GetQuote(new GetQuotesRequest
             {
                 HouseValue = houseValue
             });
@@ -99,7 +99,7 @@ namespace OpenMoney.InterviewExercise.Tests
         }
         
         [Fact]
-        public void GetQuote_ShouldReturnNull_When_No_Quotes_Returned()
+        public async Task GetQuote_ShouldReturnNull_When_No_Quotes_Returned()
         {
             const decimal houseValue = 100_000;
 
@@ -108,7 +108,7 @@ namespace OpenMoney.InterviewExercise.Tests
                     r.ContentsValue == 50_000 && r.HouseValue == houseValue)))
                 .ReturnsAsync(Enumerable.Empty<ThirdPartyHomeInsuranceResponse>());
 
-            var quote = _homeInsuranceClient.GetQuote(new GetQuotesRequest
+            var quote = await _homeInsuranceClient.GetQuote(new GetQuotesRequest
             {
                 HouseValue = houseValue
             });

--- a/OpenMoney.InterviewExercise.Tests/MortgageQuoteClientFixture.cs
+++ b/OpenMoney.InterviewExercise.Tests/MortgageQuoteClientFixture.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using Moq;
 using OpenMoney.InterviewExercise.Models;
 using OpenMoney.InterviewExercise.QuoteClients;
@@ -121,6 +122,25 @@ namespace OpenMoney.InterviewExercise.Tests
             });
             
             Assert.Equal(100m, (decimal)quote.MonthlyPayment);
+        }
+
+        [Fact]
+        public void GetQuote_ShouldReturnNull_When_No_Quotes_Returned()
+        {
+            const float deposit = 10_000;
+            const float houseValue = 100_000;
+
+            _apiMock
+                .Setup(api => api.GetQuotes(It.IsAny<ThirdPartyMortgageRequest>()))
+                .ReturnsAsync(Enumerable.Empty<ThirdPartyMortgageResponse>());
+
+            var quote = _mortgageClient.GetQuote(new GetQuotesRequest
+            {
+                Deposit = deposit,
+                HouseValue = houseValue
+            });
+
+            Assert.Null(quote);
         }
     }
 }

--- a/OpenMoney.InterviewExercise.Tests/MortgageQuoteClientFixture.cs
+++ b/OpenMoney.InterviewExercise.Tests/MortgageQuoteClientFixture.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading.Tasks;
 using Moq;
 using OpenMoney.InterviewExercise.Models;
 using OpenMoney.InterviewExercise.QuoteClients;
@@ -18,12 +19,12 @@ namespace OpenMoney.InterviewExercise.Tests
         }
 
         [Fact]
-        public void GetQuote_ShouldReturnNull_If_LTV_Under_10percent()
+        public async Task GetQuote_ShouldReturnNull_If_LTV_Under_10percent()
         {
             const decimal deposit = 99_999;
             const decimal houseValue = 1_000_000;
             
-            var quote = _mortgageClient.GetQuote(new GetQuotesRequest
+            var quote = await _mortgageClient.GetQuote(new GetQuotesRequest
             {
                 Deposit = deposit,
                 HouseValue = houseValue
@@ -33,7 +34,7 @@ namespace OpenMoney.InterviewExercise.Tests
         }
 
         [Fact]
-        public void GetQuote_ShouldReturnQuote_If_LTV_Exactly_10percent()
+        public async Task GetQuote_ShouldReturnQuote_If_LTV_Exactly_10percent()
         {
             const decimal deposit = 100_000;
             const decimal houseValue = 1_000_000;
@@ -45,7 +46,7 @@ namespace OpenMoney.InterviewExercise.Tests
                     new ThirdPartyMortgageResponse { MonthlyPayment = 300m }
                 });
 
-            var quote = _mortgageClient.GetQuote(new GetQuotesRequest
+            var quote = await _mortgageClient.GetQuote(new GetQuotesRequest
             {
                 Deposit = deposit,
                 HouseValue = houseValue
@@ -55,7 +56,7 @@ namespace OpenMoney.InterviewExercise.Tests
         }
 
         [Fact]
-        public void GetQuote_ShouldReturnMonthlyPayment_When_Only_One_Returned()
+        public async Task GetQuote_ShouldReturnMonthlyPayment_When_Only_One_Returned()
         {
             const decimal deposit = 10_000;
             const decimal houseValue = 100_000;
@@ -67,7 +68,7 @@ namespace OpenMoney.InterviewExercise.Tests
                     new ThirdPartyMortgageResponse { MonthlyPayment = 300m }
                 });
             
-            var quote = _mortgageClient.GetQuote(new GetQuotesRequest
+            var quote = await _mortgageClient.GetQuote(new GetQuotesRequest
             {
                 Deposit = deposit,
                 HouseValue = houseValue
@@ -77,7 +78,7 @@ namespace OpenMoney.InterviewExercise.Tests
         }
         
         [Fact]
-        public void GetQuote_ShouldReturnLowestMonthlyPayment_When_Multiple_Quotes_Returned()
+        public async Task GetQuote_ShouldReturnLowestMonthlyPayment_When_Multiple_Quotes_Returned()
         {
             const decimal deposit = 10_000;
             const decimal houseValue = 100_000;
@@ -91,7 +92,7 @@ namespace OpenMoney.InterviewExercise.Tests
                     new ThirdPartyMortgageResponse { MonthlyPayment = 900m },
                 });
 
-            var quote = _mortgageClient.GetQuote(new GetQuotesRequest
+            var quote = await _mortgageClient.GetQuote(new GetQuotesRequest
             {
                 Deposit = deposit,
                 HouseValue = houseValue
@@ -101,7 +102,7 @@ namespace OpenMoney.InterviewExercise.Tests
         }
 
         [Fact]
-        public void GetQuote_Should_Pass_Correct_Mortgage_Amount_To_ThirdParty()
+        public async Task GetQuote_Should_Pass_Correct_Mortgage_Amount_To_ThirdParty()
         {
             const decimal deposit = 10_000;
             const decimal houseValue = 100_000;
@@ -115,7 +116,7 @@ namespace OpenMoney.InterviewExercise.Tests
                     new ThirdPartyMortgageResponse {MonthlyPayment = 100m},
                 });
 
-            var quote = _mortgageClient.GetQuote(new GetQuotesRequest
+            var quote = await _mortgageClient.GetQuote(new GetQuotesRequest
             {
                 Deposit = deposit,
                 HouseValue = houseValue
@@ -125,7 +126,7 @@ namespace OpenMoney.InterviewExercise.Tests
         }
 
         [Fact]
-        public void GetQuote_ShouldReturnNull_When_No_Quotes_Returned()
+        public async Task GetQuote_ShouldReturnNull_When_No_Quotes_Returned()
         {
             const decimal deposit = 10_000;
             const decimal houseValue = 100_000;
@@ -134,7 +135,7 @@ namespace OpenMoney.InterviewExercise.Tests
                 .Setup(api => api.GetQuotes(It.IsAny<ThirdPartyMortgageRequest>()))
                 .ReturnsAsync(Enumerable.Empty<ThirdPartyMortgageResponse>());
 
-            var quote = _mortgageClient.GetQuote(new GetQuotesRequest
+            var quote = await _mortgageClient.GetQuote(new GetQuotesRequest
             {
                 Deposit = deposit,
                 HouseValue = houseValue

--- a/OpenMoney.InterviewExercise.Tests/MortgageQuoteClientFixture.cs
+++ b/OpenMoney.InterviewExercise.Tests/MortgageQuoteClientFixture.cs
@@ -98,5 +98,29 @@ namespace OpenMoney.InterviewExercise.Tests
 
             Assert.Equal(100m, (decimal)quote.MonthlyPayment);
         }
+
+        [Fact]
+        public void GetQuote_Should_Pass_Correct_Mortgage_Amount_To_ThirdParty()
+        {
+            const float deposit = 10_000;
+            const float houseValue = 100_000;
+
+            _apiMock
+                .Setup(api => api.GetQuotes(
+                    It.Is<ThirdPartyMortgageRequest>(r => r.MortgageAmount == 90_000)
+                ))
+                .ReturnsAsync(new[]
+                {
+                    new ThirdPartyMortgageResponse {MonthlyPayment = 100m},
+                });
+
+            var quote = _mortgageClient.GetQuote(new GetQuotesRequest
+            {
+                Deposit = deposit,
+                HouseValue = houseValue
+            });
+            
+            Assert.Equal(100m, (decimal)quote.MonthlyPayment);
+        }
     }
 }

--- a/OpenMoney.InterviewExercise.Tests/MortgageQuoteClientFixture.cs
+++ b/OpenMoney.InterviewExercise.Tests/MortgageQuoteClientFixture.cs
@@ -169,5 +169,21 @@ namespace OpenMoney.InterviewExercise.Tests
             Assert.False(quote.Succeeded);
             Assert.Equal("Test exception message", quote.ErrorMessage);
         }
+
+        [Fact]
+        public async Task GetQuote_ShouldReturnFailure_If_Mortgage_Amount_Is_Negative()
+        {
+            const decimal deposit = 1_000_000;
+            const decimal houseValue = 100_000;
+            
+            var quote = await _mortgageClient.GetQuote(new GetQuotesRequest
+            {
+                Deposit = deposit,
+                HouseValue = houseValue
+            });
+
+            Assert.False(quote.Succeeded);
+            Assert.Equal("Mortgage amount cannot be negative", quote.ErrorMessage);
+        }
     }
 }

--- a/OpenMoney.InterviewExercise.Tests/MortgageQuoteClientFixture.cs
+++ b/OpenMoney.InterviewExercise.Tests/MortgageQuoteClientFixture.cs
@@ -9,15 +9,20 @@ namespace OpenMoney.InterviewExercise.Tests
     public class MortgageQuoteClientFixture
     {
         private readonly Mock<IThirdPartyMortgageApi> _apiMock = new();
+        private readonly MortgageQuoteClient _mortgageClient;
+
+        public MortgageQuoteClientFixture()
+        {
+            _mortgageClient = new MortgageQuoteClient(_apiMock.Object);
+        }
 
         [Fact]
-        public void GetQuote_ShouldReturnNull_IfHouseValue_Over10Mill()
+        public void GetQuote_ShouldReturnNull_If_LTV_Under_10percent()
         {
-            const float deposit = 9_000;
-            const float houseValue = 100_000;
+            const float deposit = 99_999;
+            const float houseValue = 1_000_000;
             
-            var mortgageClient = new MortgageQuoteClient(_apiMock.Object);
-            var quote = mortgageClient.GetQuote(new GetQuotesRequest
+            var quote = _mortgageClient.GetQuote(new GetQuotesRequest
             {
                 Deposit = deposit,
                 HouseValue = houseValue
@@ -27,7 +32,29 @@ namespace OpenMoney.InterviewExercise.Tests
         }
 
         [Fact]
-        public void GetQuote_ShouldReturn_AQuote()
+        public void GetQuote_ShouldReturnQuote_If_LTV_Exactly_10percent()
+        {
+            const float deposit = 100_000;
+            const float houseValue = 1_000_000;
+
+            _apiMock
+                .Setup(api => api.GetQuotes(It.IsAny<ThirdPartyMortgageRequest>()))
+                .ReturnsAsync(new[]
+                {
+                    new ThirdPartyMortgageResponse { MonthlyPayment = 300m }
+                });
+
+            var quote = _mortgageClient.GetQuote(new GetQuotesRequest
+            {
+                Deposit = deposit,
+                HouseValue = houseValue
+            });
+
+            Assert.NotNull(quote);
+        }
+
+        [Fact]
+        public void GetQuote_ShouldReturnMonthlyPayment_When_Only_One_Returned()
         {
             const float deposit = 10_000;
             const float houseValue = 100_000;
@@ -39,14 +66,37 @@ namespace OpenMoney.InterviewExercise.Tests
                     new ThirdPartyMortgageResponse { MonthlyPayment = 300m }
                 });
             
-            var mortgageClient = new MortgageQuoteClient(_apiMock.Object);
-            var quote = mortgageClient.GetQuote(new GetQuotesRequest
+            var quote = _mortgageClient.GetQuote(new GetQuotesRequest
             {
                 Deposit = deposit,
                 HouseValue = houseValue
             });
             
             Assert.Equal(300m, (decimal)quote.MonthlyPayment);
+        }
+        
+        [Fact]
+        public void GetQuote_ShouldReturnLowestMonthlyPayment_When_Multiple_Quotes_Returned()
+        {
+            const float deposit = 10_000;
+            const float houseValue = 100_000;
+
+            _apiMock
+                .Setup(api => api.GetQuotes(It.IsAny<ThirdPartyMortgageRequest>()))
+                .ReturnsAsync(new[]
+                {
+                    new ThirdPartyMortgageResponse { MonthlyPayment = 300m },
+                    new ThirdPartyMortgageResponse { MonthlyPayment = 100m },
+                    new ThirdPartyMortgageResponse { MonthlyPayment = 900m },
+                });
+
+            var quote = _mortgageClient.GetQuote(new GetQuotesRequest
+            {
+                Deposit = deposit,
+                HouseValue = houseValue
+            });
+
+            Assert.Equal(100m, (decimal)quote.MonthlyPayment);
         }
     }
 }

--- a/OpenMoney.InterviewExercise.Tests/MortgageQuoteClientFixture.cs
+++ b/OpenMoney.InterviewExercise.Tests/MortgageQuoteClientFixture.cs
@@ -20,8 +20,8 @@ namespace OpenMoney.InterviewExercise.Tests
         [Fact]
         public void GetQuote_ShouldReturnNull_If_LTV_Under_10percent()
         {
-            const float deposit = 99_999;
-            const float houseValue = 1_000_000;
+            const decimal deposit = 99_999;
+            const decimal houseValue = 1_000_000;
             
             var quote = _mortgageClient.GetQuote(new GetQuotesRequest
             {
@@ -35,8 +35,8 @@ namespace OpenMoney.InterviewExercise.Tests
         [Fact]
         public void GetQuote_ShouldReturnQuote_If_LTV_Exactly_10percent()
         {
-            const float deposit = 100_000;
-            const float houseValue = 1_000_000;
+            const decimal deposit = 100_000;
+            const decimal houseValue = 1_000_000;
 
             _apiMock
                 .Setup(api => api.GetQuotes(It.IsAny<ThirdPartyMortgageRequest>()))
@@ -57,8 +57,8 @@ namespace OpenMoney.InterviewExercise.Tests
         [Fact]
         public void GetQuote_ShouldReturnMonthlyPayment_When_Only_One_Returned()
         {
-            const float deposit = 10_000;
-            const float houseValue = 100_000;
+            const decimal deposit = 10_000;
+            const decimal houseValue = 100_000;
 
             _apiMock
                 .Setup(api => api.GetQuotes(It.IsAny<ThirdPartyMortgageRequest>()))
@@ -73,14 +73,14 @@ namespace OpenMoney.InterviewExercise.Tests
                 HouseValue = houseValue
             });
             
-            Assert.Equal(300m, (decimal)quote.MonthlyPayment);
+            Assert.Equal(300m, quote.MonthlyPayment);
         }
         
         [Fact]
         public void GetQuote_ShouldReturnLowestMonthlyPayment_When_Multiple_Quotes_Returned()
         {
-            const float deposit = 10_000;
-            const float houseValue = 100_000;
+            const decimal deposit = 10_000;
+            const decimal houseValue = 100_000;
 
             _apiMock
                 .Setup(api => api.GetQuotes(It.IsAny<ThirdPartyMortgageRequest>()))
@@ -97,14 +97,14 @@ namespace OpenMoney.InterviewExercise.Tests
                 HouseValue = houseValue
             });
 
-            Assert.Equal(100m, (decimal)quote.MonthlyPayment);
+            Assert.Equal(100m, quote.MonthlyPayment);
         }
 
         [Fact]
         public void GetQuote_Should_Pass_Correct_Mortgage_Amount_To_ThirdParty()
         {
-            const float deposit = 10_000;
-            const float houseValue = 100_000;
+            const decimal deposit = 10_000;
+            const decimal houseValue = 100_000;
 
             _apiMock
                 .Setup(api => api.GetQuotes(
@@ -121,14 +121,14 @@ namespace OpenMoney.InterviewExercise.Tests
                 HouseValue = houseValue
             });
             
-            Assert.Equal(100m, (decimal)quote.MonthlyPayment);
+            Assert.Equal(100m, quote.MonthlyPayment);
         }
 
         [Fact]
         public void GetQuote_ShouldReturnNull_When_No_Quotes_Returned()
         {
-            const float deposit = 10_000;
-            const float houseValue = 100_000;
+            const decimal deposit = 10_000;
+            const decimal houseValue = 100_000;
 
             _apiMock
                 .Setup(api => api.GetQuotes(It.IsAny<ThirdPartyMortgageRequest>()))

--- a/OpenMoney.InterviewExercise.Tests/QuoteOrchestratorFixture.cs
+++ b/OpenMoney.InterviewExercise.Tests/QuoteOrchestratorFixture.cs
@@ -20,8 +20,8 @@ namespace OpenMoney.InterviewExercise.Tests
         [Fact]
         public void GetQuotes_ShouldPassCorrectValuesToMortgageClient_AndReturnQuote()
         {
-            const float deposit = 10_000;
-            const float houseValue = 100_000;
+            const decimal deposit = 10_000;
+            const decimal houseValue = 100_000;
 
             var request = new GetQuotesRequest
             {
@@ -44,8 +44,8 @@ namespace OpenMoney.InterviewExercise.Tests
         [Fact]
         public void GetQuotes_ShouldPassCorrectValuesToHomeInsuranceClient_AndReturnQuote()
         {
-            const float deposit = 10_000;
-            const float houseValue = 100_000;
+            const decimal deposit = 10_000;
+            const decimal houseValue = 100_000;
 
             var request = new GetQuotesRequest
             {

--- a/OpenMoney.InterviewExercise.Tests/QuoteOrchestratorFixture.cs
+++ b/OpenMoney.InterviewExercise.Tests/QuoteOrchestratorFixture.cs
@@ -10,17 +10,19 @@ namespace OpenMoney.InterviewExercise.Tests
     {
         private readonly Mock<IMortgageQuoteClient> _mortgageClientMock = new();
         private readonly Mock<IHomeInsuranceQuoteClient> _homeInsuranceClientMock = new();
-        
+        private readonly QuoteOrchestrator _orchestrator;
+
+        public QuoteOrchestratorFixture()
+        {
+            _orchestrator = new QuoteOrchestrator(_homeInsuranceClientMock.Object, _mortgageClientMock.Object); 
+        }
+
         [Fact]
         public void GetQuotes_ShouldPassCorrectValuesToMortgageClient_AndReturnQuote()
         {
-            var orchetrator = new QuoteOrchestrator(
-                _homeInsuranceClientMock.Object,
-                _mortgageClientMock.Object);
-
             const float deposit = 10_000;
             const float houseValue = 100_000;
-            
+
             var request = new GetQuotesRequest
             {
                 Deposit = deposit,
@@ -34,7 +36,7 @@ namespace OpenMoney.InterviewExercise.Tests
                     MonthlyPayment = 700
                 });
             
-            var response = orchetrator.GetQuotes(request);
+            var response = _orchestrator.GetQuotes(request);
             
             Assert.Equal(700, response.MortgageQuote.MonthlyPayment);
         }
@@ -42,13 +44,9 @@ namespace OpenMoney.InterviewExercise.Tests
         [Fact]
         public void GetQuotes_ShouldPassCorrectValuesToHomeInsuranceClient_AndReturnQuote()
         {
-            var orchetrator = new QuoteOrchestrator(
-                _homeInsuranceClientMock.Object,
-                _mortgageClientMock.Object);
-
             const float deposit = 10_000;
             const float houseValue = 100_000;
-            
+
             var request = new GetQuotesRequest
             {
                 Deposit = deposit,
@@ -62,7 +60,7 @@ namespace OpenMoney.InterviewExercise.Tests
                     MonthlyPayment = 600
                 });
             
-            var response = orchetrator.GetQuotes(request);
+            var response = _orchestrator.GetQuotes(request);
             
             Assert.Equal(600, response.HomeInsuranceQuote.MonthlyPayment);
         }

--- a/OpenMoney.InterviewExercise.Tests/QuoteOrchestratorFixture.cs
+++ b/OpenMoney.InterviewExercise.Tests/QuoteOrchestratorFixture.cs
@@ -1,3 +1,4 @@
+using System.Threading.Tasks;
 using Moq;
 using OpenMoney.InterviewExercise.Models;
 using OpenMoney.InterviewExercise.Models.Quotes;
@@ -18,7 +19,7 @@ namespace OpenMoney.InterviewExercise.Tests
         }
 
         [Fact]
-        public void GetQuotes_ShouldPassCorrectValuesToMortgageClient_AndReturnQuote()
+        public async Task GetQuotes_ShouldPassCorrectValuesToMortgageClient_AndReturnQuote()
         {
             const decimal deposit = 10_000;
             const decimal houseValue = 100_000;
@@ -31,18 +32,18 @@ namespace OpenMoney.InterviewExercise.Tests
 
             _mortgageClientMock
                 .Setup(m => m.GetQuote(request))
-                .Returns(new MortgageQuote
+                .ReturnsAsync(new MortgageQuote
                 {
                     MonthlyPayment = 700
                 });
             
-            var response = _orchestrator.GetQuotes(request);
+            var response = await _orchestrator.GetQuotes(request);
             
             Assert.Equal(700, response.MortgageQuote.MonthlyPayment);
         }
         
         [Fact]
-        public void GetQuotes_ShouldPassCorrectValuesToHomeInsuranceClient_AndReturnQuote()
+        public async Task GetQuotes_ShouldPassCorrectValuesToHomeInsuranceClient_AndReturnQuote()
         {
             const decimal deposit = 10_000;
             const decimal houseValue = 100_000;
@@ -55,12 +56,12 @@ namespace OpenMoney.InterviewExercise.Tests
 
             _homeInsuranceClientMock
                 .Setup(m => m.GetQuote(request))
-                .Returns(new HomeInsuranceQuote
+                .ReturnsAsync(new HomeInsuranceQuote
                 {
                     MonthlyPayment = 600
                 });
             
-            var response = _orchestrator.GetQuotes(request);
+            var response = await _orchestrator.GetQuotes(request);
             
             Assert.Equal(600, response.HomeInsuranceQuote.MonthlyPayment);
         }

--- a/OpenMoney.InterviewExercise/Models/GetQuotesRequest.cs
+++ b/OpenMoney.InterviewExercise/Models/GetQuotesRequest.cs
@@ -2,7 +2,7 @@ namespace OpenMoney.InterviewExercise.Models
 {
     public class GetQuotesRequest
     {
-        public float HouseValue { get; set; }
-        public float Deposit { get; set; }
+        public decimal HouseValue { get; set; }
+        public decimal Deposit { get; set; }
     }
 }

--- a/OpenMoney.InterviewExercise/Models/Quotes/HomeInsuranceQuote.cs
+++ b/OpenMoney.InterviewExercise/Models/Quotes/HomeInsuranceQuote.cs
@@ -2,6 +2,19 @@ namespace OpenMoney.InterviewExercise.Models.Quotes
 {
     public class HomeInsuranceQuote
     {
+        public bool Succeeded { get; set; }
+        public string ErrorMessage { get; set; }
+
         public decimal MonthlyPayment { get; set; }
+
+        public static HomeInsuranceQuote Failure(string message)
+        {
+            return new HomeInsuranceQuote { Succeeded = false, ErrorMessage = message };
+        }
+
+        public static HomeInsuranceQuote Success(decimal monthlyPayment)
+        {
+            return new HomeInsuranceQuote { Succeeded = true, MonthlyPayment = monthlyPayment };
+        }
     }
 }

--- a/OpenMoney.InterviewExercise/Models/Quotes/HomeInsuranceQuote.cs
+++ b/OpenMoney.InterviewExercise/Models/Quotes/HomeInsuranceQuote.cs
@@ -2,9 +2,6 @@ namespace OpenMoney.InterviewExercise.Models.Quotes
 {
     public class HomeInsuranceQuote
     {
-        public float MonthlyPayment { get; set; }
-        public float BuildingsCover { get; set; }
-        public float ContentsCover { get; set; }
-        //public int LengthInMonths { get; set; }
+        public decimal MonthlyPayment { get; set; }
     }
 }

--- a/OpenMoney.InterviewExercise/Models/Quotes/MortgageQuote.cs
+++ b/OpenMoney.InterviewExercise/Models/Quotes/MortgageQuote.cs
@@ -2,6 +2,19 @@ namespace OpenMoney.InterviewExercise.Models.Quotes
 {
     public class MortgageQuote
     {
+        public bool Succeeded { get; set; }
+        public string ErrorMessage { get; set; }
+
         public decimal MonthlyPayment { get; set; }
+
+        public static MortgageQuote Failure(string message)
+        {
+            return new MortgageQuote {Succeeded = false, ErrorMessage = message};
+        }
+
+        public static MortgageQuote Success(decimal monthlyPayment)
+        {
+            return new MortgageQuote { Succeeded = true, MonthlyPayment = monthlyPayment };
+        }
     }
 }

--- a/OpenMoney.InterviewExercise/Models/Quotes/MortgageQuote.cs
+++ b/OpenMoney.InterviewExercise/Models/Quotes/MortgageQuote.cs
@@ -2,6 +2,6 @@ namespace OpenMoney.InterviewExercise.Models.Quotes
 {
     public class MortgageQuote
     {
-        public float MonthlyPayment { get; set; }
+        public decimal MonthlyPayment { get; set; }
     }
 }

--- a/OpenMoney.InterviewExercise/QuoteClients/HomeInsuranceQuoteClient.cs
+++ b/OpenMoney.InterviewExercise/QuoteClients/HomeInsuranceQuoteClient.cs
@@ -52,6 +52,9 @@ namespace OpenMoney.InterviewExercise.QuoteClients
                     cheapestQuote = quote;
                 }
             }
+
+            if (cheapestQuote is null)
+                return null;
             
             return new HomeInsuranceQuote
             {

--- a/OpenMoney.InterviewExercise/QuoteClients/HomeInsuranceQuoteClient.cs
+++ b/OpenMoney.InterviewExercise/QuoteClients/HomeInsuranceQuoteClient.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading.Tasks;
 using OpenMoney.InterviewExercise.Models;
 using OpenMoney.InterviewExercise.Models.Quotes;
 using OpenMoney.InterviewExercise.ThirdParties;
@@ -7,7 +8,7 @@ namespace OpenMoney.InterviewExercise.QuoteClients
 {
     public interface IHomeInsuranceQuoteClient
     {
-        HomeInsuranceQuote GetQuote(GetQuotesRequest getQuotesRequest);
+        Task<HomeInsuranceQuote> GetQuote(GetQuotesRequest getQuotesRequest);
     }
 
     public class HomeInsuranceQuoteClient : IHomeInsuranceQuoteClient
@@ -21,7 +22,7 @@ namespace OpenMoney.InterviewExercise.QuoteClients
             _api = api;
         }
 
-        public HomeInsuranceQuote GetQuote(GetQuotesRequest getQuotesRequest)
+        public async Task<HomeInsuranceQuote> GetQuote(GetQuotesRequest getQuotesRequest)
         {
             // check if request is eligible
             if (getQuotesRequest.HouseValue > 10_000_000m)
@@ -35,11 +36,11 @@ namespace OpenMoney.InterviewExercise.QuoteClients
                 ContentsValue = contentsValue
             };
 
-            var response = _api.GetQuotes(request).GetAwaiter().GetResult().ToArray();
+            var response = (await _api.GetQuotes(request)).ToList();
 
             ThirdPartyHomeInsuranceResponse cheapestQuote = null;
             
-            for (var i = 0; i < response.Length; i++)
+            for (var i = 0; i < response.Count; i++)
             {
                 var quote = response[i];
 

--- a/OpenMoney.InterviewExercise/QuoteClients/HomeInsuranceQuoteClient.cs
+++ b/OpenMoney.InterviewExercise/QuoteClients/HomeInsuranceQuoteClient.cs
@@ -12,7 +12,7 @@ namespace OpenMoney.InterviewExercise.QuoteClients
 
     public class HomeInsuranceQuoteClient : IHomeInsuranceQuoteClient
     {
-        private IThirdPartyHomeInsuranceApi _api;
+        private readonly IThirdPartyHomeInsuranceApi _api;
         
         public decimal contentsValue = 50_000;
 
@@ -24,7 +24,7 @@ namespace OpenMoney.InterviewExercise.QuoteClients
         public HomeInsuranceQuote GetQuote(GetQuotesRequest getQuotesRequest)
         {
             // check if request is eligible
-            if (getQuotesRequest.HouseValue > 10_000_000d)
+            if (getQuotesRequest.HouseValue > 10_000_000m)
             {
                 return null;
             }
@@ -58,7 +58,7 @@ namespace OpenMoney.InterviewExercise.QuoteClients
             
             return new HomeInsuranceQuote
             {
-                MonthlyPayment = (float) cheapestQuote.MonthlyPayment
+                MonthlyPayment = (decimal)cheapestQuote.MonthlyPayment
             };
         }
     }

--- a/OpenMoney.InterviewExercise/QuoteClients/MortgageQuoteClient.cs
+++ b/OpenMoney.InterviewExercise/QuoteClients/MortgageQuoteClient.cs
@@ -52,6 +52,9 @@ namespace OpenMoney.InterviewExercise.QuoteClients
                     cheapestQuote = quote;
                 }
             }
+
+            if (cheapestQuote is null)
+                return null;
             
             return new MortgageQuote
             {

--- a/OpenMoney.InterviewExercise/QuoteClients/MortgageQuoteClient.cs
+++ b/OpenMoney.InterviewExercise/QuoteClients/MortgageQuoteClient.cs
@@ -28,7 +28,7 @@ namespace OpenMoney.InterviewExercise.QuoteClients
                 return null;
             }
             
-            var mortgageAmount = getQuotesRequest.Deposit - getQuotesRequest.HouseValue;
+            var mortgageAmount = getQuotesRequest.HouseValue - getQuotesRequest.Deposit;
             
             var request = new ThirdPartyMortgageRequest
             {

--- a/OpenMoney.InterviewExercise/QuoteClients/MortgageQuoteClient.cs
+++ b/OpenMoney.InterviewExercise/QuoteClients/MortgageQuoteClient.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using System.Threading.Tasks;
 using OpenMoney.InterviewExercise.Models;
 using OpenMoney.InterviewExercise.Models.Quotes;
 using OpenMoney.InterviewExercise.ThirdParties;
@@ -7,7 +8,7 @@ namespace OpenMoney.InterviewExercise.QuoteClients
 {
     public interface IMortgageQuoteClient
     {
-        MortgageQuote GetQuote(GetQuotesRequest getQuotesRequest);
+        Task<MortgageQuote> GetQuote(GetQuotesRequest getQuotesRequest);
     }
 
     public class MortgageQuoteClient : IMortgageQuoteClient
@@ -19,7 +20,7 @@ namespace OpenMoney.InterviewExercise.QuoteClients
             _api = api;
         }
         
-        public MortgageQuote GetQuote(GetQuotesRequest getQuotesRequest)
+        public async Task<MortgageQuote> GetQuote(GetQuotesRequest getQuotesRequest)
         {
             // check if mortgage request is eligible
             var loanToValueFraction = getQuotesRequest.Deposit / getQuotesRequest.HouseValue;
@@ -35,11 +36,11 @@ namespace OpenMoney.InterviewExercise.QuoteClients
                 MortgageAmount = (decimal) mortgageAmount
             };
 
-            var response = _api.GetQuotes(request).GetAwaiter().GetResult().ToArray();
+            var response = (await _api.GetQuotes(request)).ToList();
 
             ThirdPartyMortgageResponse cheapestQuote = null;
             
-            for (var i = 0; i < response.Length; i++)
+            for (var i = 0; i < response.Count; i++)
             {
                 var quote = response[i];
 

--- a/OpenMoney.InterviewExercise/QuoteClients/MortgageQuoteClient.cs
+++ b/OpenMoney.InterviewExercise/QuoteClients/MortgageQuoteClient.cs
@@ -27,6 +27,8 @@ namespace OpenMoney.InterviewExercise.QuoteClients
                 return MortgageQuote.Failure("Loan-to-value must be over 10%");
 
             var mortgageAmount = getQuotesRequest.HouseValue - getQuotesRequest.Deposit;
+            if (mortgageAmount < 0)
+                return MortgageQuote.Failure("Mortgage amount cannot be negative");
 
             var request = new ThirdPartyMortgageRequest
             {

--- a/OpenMoney.InterviewExercise/QuoteClients/MortgageQuoteClient.cs
+++ b/OpenMoney.InterviewExercise/QuoteClients/MortgageQuoteClient.cs
@@ -23,7 +23,7 @@ namespace OpenMoney.InterviewExercise.QuoteClients
         {
             // check if mortgage request is eligible
             var loanToValueFraction = getQuotesRequest.Deposit / getQuotesRequest.HouseValue;
-            if (loanToValueFraction < 0.1d)
+            if (loanToValueFraction < 0.1m)
             {
                 return null;
             }
@@ -58,7 +58,7 @@ namespace OpenMoney.InterviewExercise.QuoteClients
             
             return new MortgageQuote
             {
-                MonthlyPayment = (float) cheapestQuote.MonthlyPayment
+                MonthlyPayment = cheapestQuote.MonthlyPayment
             };
         }
     }

--- a/OpenMoney.InterviewExercise/QuoteOrchestrator.cs
+++ b/OpenMoney.InterviewExercise/QuoteOrchestrator.cs
@@ -1,4 +1,5 @@
-﻿using OpenMoney.InterviewExercise.Models;
+﻿using System.Threading.Tasks;
+using OpenMoney.InterviewExercise.Models;
 using OpenMoney.InterviewExercise.QuoteClients;
 
 namespace OpenMoney.InterviewExercise
@@ -16,12 +17,17 @@ namespace OpenMoney.InterviewExercise
             _mortgageQuoteClient = mortgageQuoteClient;
         }
 
-        public GetQuotesResponse GetQuotes(GetQuotesRequest request)
+        public async Task<GetQuotesResponse> GetQuotes(GetQuotesRequest request)
         {
+            var mortgageQuote = _mortgageQuoteClient.GetQuote(request);
+            var homeInsuranceQuote = _homeInsuranceQuoteClient.GetQuote(request);
+
+            await Task.WhenAll(mortgageQuote, homeInsuranceQuote);
+
             return new GetQuotesResponse
             {
-                MortgageQuote = _mortgageQuoteClient.GetQuote(request),
-                HomeInsuranceQuote = _homeInsuranceQuoteClient.GetQuote(request)
+                MortgageQuote = mortgageQuote.Result,
+                HomeInsuranceQuote = homeInsuranceQuote.Result
             };
         }
     }


### PR DESCRIPTION
PR for the OpenMoney exercise.
(in reality, this could be two PRs; the bug fixes could ship separately to the performance changes and refactoring)


Fixes the following:

**Task 1 - Bug** 
This was an incorrect calculation of the mortgage amount, and a potential edge case where a negative amount could result from a deposit that is higher than the house value.

**Task 2 - Performance**
We were blocking on the calls to the 3rd party APIs.
Using `async/await` everywhere means we can spin off both calls in parallel and wait for them both before returning the quote.
This assumes that we own the code that calls the Orchestrator, and can make that `async/await` too.

Using `decimal` everywhere (except where a 3rd party API returns a `float`) and removing a lot of casts would probably also have a minor impact.

**Task 3 - Missing tests**
More test coverage added

**Task 4 - Error Handling**
I have changed the return models from the `QuoteClient`s to indicate whether they succeeded or failed (and to return the error message).

We could have put the `try/catch`s in the Orchestrator, but I think the `Client`s are the correct place because:
- They can handle exceptions specific to their own API call
- Handling exceptions outside of the code that raised them feels like it breaks encapsulation
- We now spin up multiple `Task`s in the Orchestrator and wait for them both to complete. Handling exceptions there means the 'fun' of dealing with `AggregateException`s.


Interview Notes:

**Bonus Task**
I did not end up abstracting any of the code in the `QuoteClient` as suggested in the Bonus Task. After the code was refactored (and some helper methods added for returning success/failure) there's very little duplicated code. 

The majority of the code in those classes is now pre-conditions or error handling, both of which are specific to that client.
There is _some_ common code - like using Linq's `Min()` to find the lowest quote - but I think that code belongs in the `Client` class, since it's more readable and could very likely end up differing between the two classes later.

Please let me know if this was a mistake, I'd value the feedback.

**ContentsValue**
I noticed that this value is a hard-coded `const` in the `HomeInsuranceQuoteClient`. I wasn't sure if finding that was part of the exercise, or whether it is a deliberate requirement.

If it is not deliberate, we would remove that constant and pass the value into the method via the `GetQuotesRequest` model instead (I did not make that change in this PR).

